### PR TITLE
Add text classifier UI and data loader base

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 ## We can combined with multiple Faiss indexes from different models and construct a more robust k-NN classifier.
 
+This project now supports both image and text classification. Text inputs are embedded using
+pretrained [Sentence Transformers](https://www.sbert.net/). Select the appropriate
+`FEATURE_MODEL` and `DATA_LOADER` in your environment to switch between modalities.
+
 > **Note:** You must use a feature extractor with general training objective like imagenet or COCO.
 >
 > Only use domain specific if the new classes added to the index are in the same domain. 
@@ -34,4 +38,14 @@ npm start
 python scripts/start_api_server.py
 ```
 
+### Example API calls
 
+- Upload text samples:
+  `POST /upload_texts`
+- Classify a text string:
+  `POST /classify_text`
+
+
+
+### UI Updates
+The React frontend now includes tabs for uploading text samples and classifying arbitrary text inputs. Start the frontend with `npm start` and navigate through the new **Upload Texts** and **Classify Text** tabs to interact with the language classifier.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,7 +10,9 @@ import {
 } from "@mui/material";
 import AddClassForm from "./components/AddClassForm";
 import UploadImages from "./components/UploadImages";
+import UploadTexts from "./components/UploadTexts";
 import ClassifyImage from "./components/ClassifyImage";
+import ClassifyText from "./components/ClassifyText";
 import ClassList from "./components/ClassList";
 
 function App() {
@@ -33,7 +35,9 @@ function App() {
         <Tabs value={currentTab} onChange={handleChange} centered>
           <Tab label="Add Class" />
           <Tab label="Upload Images" />
+          <Tab label="Upload Texts" />
           <Tab label="Classify Image" />
+          <Tab label="Classify Text" />
           <Tab label="View Classes" />
         </Tabs>
         <TabPanel value={currentTab} index={0}>
@@ -43,9 +47,15 @@ function App() {
           <UploadImages />
         </TabPanel>
         <TabPanel value={currentTab} index={2}>
-          <ClassifyImage />
+          <UploadTexts />
         </TabPanel>
         <TabPanel value={currentTab} index={3}>
+          <ClassifyImage />
+        </TabPanel>
+        <TabPanel value={currentTab} index={4}>
+          <ClassifyText />
+        </TabPanel>
+        <TabPanel value={currentTab} index={5}>
           <ClassList />
         </TabPanel>
       </Container>

--- a/frontend/src/components/ClassifyText.js
+++ b/frontend/src/components/ClassifyText.js
@@ -1,0 +1,82 @@
+import React, { useState } from "react";
+import axios from "axios";
+import { Button, Box, Typography, TextField, CircularProgress } from "@mui/material";
+
+const ClassifyText = () => {
+  const [text, setText] = useState("");
+  const [prediction, setPrediction] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleClassify = async (e) => {
+    e.preventDefault();
+    if (!text.trim()) {
+      setError("Please enter text to classify.");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("text", text);
+
+    setLoading(true);
+    setPrediction("");
+    setError("");
+
+    try {
+      const response = await axios.post(
+        "http://localhost:8000/classify_text",
+        formData,
+        {
+          headers: {
+            "Content-Type": "multipart/form-data",
+          },
+        },
+      );
+      setPrediction(response.data.prediction);
+    } catch (err) {
+      if (err.response && err.response.data.detail) {
+        setError(err.response.data.detail);
+      } else {
+        setError("An error occurred during classification.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box component="form" onSubmit={handleClassify} sx={{ mt: 5 }}>
+      <Typography variant="h6">Classify Text</Typography>
+      <TextField
+        label="Text"
+        multiline
+        fullWidth
+        rows={4}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        sx={{ mt: 2 }}
+      />
+      <Button
+        type="submit"
+        variant="contained"
+        color="primary"
+        sx={{ mt: 2 }}
+        disabled={loading}
+      >
+        {loading ? <CircularProgress size={24} /> : "Classify Text"}
+      </Button>
+      {prediction && (
+        <Typography variant="h6" color="success.main" sx={{ mt: 2 }}>
+          Prediction: {prediction}
+        </Typography>
+      )}
+      {error && (
+        <Typography variant="body2" color="error" sx={{ mt: 2 }}>
+          {error}
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default ClassifyText;

--- a/frontend/src/components/UploadTexts.js
+++ b/frontend/src/components/UploadTexts.js
@@ -1,0 +1,132 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import {
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button,
+  Box,
+  Typography,
+  CircularProgress,
+} from "@mui/material";
+
+const UploadTexts = () => {
+  const [classes, setClasses] = useState([]);
+  const [selectedClass, setSelectedClass] = useState("");
+  const [files, setFiles] = useState([]);
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchClasses = async () => {
+      try {
+        const response = await axios.get("http://localhost:8000/classes");
+        setClasses(response.data.classes);
+      } catch (error) {
+        setMessage("Failed to fetch classes.");
+      }
+    };
+    fetchClasses();
+  }, []);
+
+  const handleFileChange = (e) => {
+    setFiles(e.target.files);
+  };
+
+  const handleUpload = async (e) => {
+    e.preventDefault();
+    if (!selectedClass) {
+      setMessage("Please select a class.");
+      return;
+    }
+    if (files.length === 0) {
+      setMessage("Please select at least one text file to upload.");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("class_name", selectedClass);
+    for (let i = 0; i < files.length; i++) {
+      formData.append("files", files[i]);
+    }
+
+    setLoading(true);
+    setMessage("");
+
+    try {
+      const response = await axios.post(
+        "http://localhost:8000/upload_texts",
+        formData,
+        {
+          headers: {
+            "Content-Type": "multipart/form-data",
+          },
+        },
+      );
+      setMessage(response.data.message);
+      setFiles([]);
+    } catch (error) {
+      if (error.response && error.response.data.detail) {
+        setMessage(error.response.data.detail);
+      } else {
+        setMessage("An error occurred while uploading texts.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box component="form" onSubmit={handleUpload} sx={{ mt: 5 }}>
+      <Typography variant="h6">Upload Texts to Class</Typography>
+      <FormControl fullWidth sx={{ mt: 2 }}>
+        <InputLabel id="select-text-class-label">Select Class</InputLabel>
+        <Select
+          labelId="select-text-class-label"
+          value={selectedClass}
+          label="Select Class"
+          onChange={(e) => setSelectedClass(e.target.value)}
+          required
+        >
+          {classes.map((cls) => (
+            <MenuItem key={cls} value={cls}>
+              {cls}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <Button variant="contained" component="label" sx={{ mt: 2 }}>
+        Select Text Files
+        <input
+          type="file"
+          hidden
+          multiple
+          accept=".txt"
+          onChange={handleFileChange}
+        />
+      </Button>
+      {files.length > 0 && (
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          {files.length} file(s) selected.
+        </Typography>
+      )}
+      <Button
+        type="submit"
+        variant="contained"
+        color="primary"
+        sx={{ mt: 2 }}
+        disabled={loading}
+      >
+        {loading ? <CircularProgress size={24} /> : "Upload Texts"}
+      </Button>
+      {message && (
+        <Typography variant="body2" color="secondary" sx={{ mt: 2 }}>
+          {message}
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default UploadTexts;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,6 @@ dependencies = [
   "torch>=2.5.1",
   "torchvision>=0.20.1",
   "tqdm>=4.67.0",
+  "sentence-transformers>=2.7.0",
   "uvicorn>=0.32.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,6 +120,7 @@ torch==2.5.1
 torchvision==0.20.1
     # via test-time-classifier (pyproject.toml)
 tqdm==4.67.0
+sentence-transformers==2.7.0
     # via test-time-classifier (pyproject.toml)
 triton==3.1.0
     # via torch

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -6,7 +6,7 @@ from fastapi import File, UploadFile, Form, HTTPException, APIRouter
 import numpy as np
 
 from src.config.settings import Settings
-from src.data.data_loader import DataLoader
+from src.data import DataLoader, TextDataLoader
 from src.database.feature_database import FeatureDatabase
 from src.search.similarity_search import SimilaritySearch
 from src.classifier.classifier import Classifier
@@ -25,7 +25,13 @@ class TestTimeRouter:
 
         logger.info("Initializing Test-Time Compute Classifier API components.")
 
-        data_loader = DataLoader(Settings.DATA_PATH)
+        try:
+            DataLoaderCls = dynamic_import("src.data", Settings.DATA_LOADER)
+        except Exception as e:
+            logger.error(f"Failed to load data loader: {e}")
+            raise HTTPException(status_code=500, detail="Failed to load data loader.")
+
+        data_loader = DataLoaderCls(Settings.DATA_PATH)
 
         try:
             feature_extractor = dynamic_import("src.features", Settings.FEATURE_MODEL)()
@@ -85,7 +91,9 @@ class TestTimeRouter:
         )
         self.router.post("/add_class", summary="Add class")(self.add_class)
         self.router.post("/upload_images", summary="Upload images")(self.upload_images)
+        self.router.post("/upload_texts", summary="Upload texts")(self.upload_texts)
         self.router.post("/classify", summary="Classify image")(self.classify_image)
+        self.router.post("/classify_text", summary="Classify text")(self.classify_text)
         self.router.get("/classes", summary="List classes")(self.list_classes)
         self.router.get("/health", summary="Health check")(self.health_check)
 
@@ -170,6 +178,57 @@ class TestTimeRouter:
             "message": f"Uploaded {len(saved_files)} images to class '{class_name}' successfully."
         }
 
+    async def upload_texts(
+        self, class_name: str = Form(...), files: List[UploadFile] = File(...)
+    ):
+        class_dir = os.path.join(Settings.DATA_PATH, class_name)
+        if not os.path.exists(class_dir):
+            logger.warning(f"Class '{class_name}' does not exist.")
+            raise HTTPException(status_code=404, detail=f"Class '{class_name}' does not exist.")
+
+        saved_files = []
+        for file in files:
+            unique_filename = f"{uuid.uuid4().hex}.txt"
+            file_path = os.path.join(class_dir, unique_filename)
+            try:
+                content = await file.read()
+                with open(file_path, "w", encoding="utf-8") as f:
+                    f.write(content.decode("utf-8"))
+                saved_files.append(unique_filename)
+                logger.info(f"Saved text {unique_filename} to class '{class_name}'.")
+            except Exception as e:
+                logger.error(f"Failed to save text '{file.filename}': {e}")
+                raise HTTPException(status_code=500, detail=f"Failed to save text '{file.filename}'.")
+            finally:
+                await file.close()
+
+        try:
+            feature_vectors = []
+            valid_labels = []
+            for fname in saved_files:
+                with open(os.path.join(class_dir, fname), "r", encoding="utf-8") as f:
+                    text = f.read()
+                feat = feature_extractor(text)
+                if feat.size > 0:
+                    feature_vectors.append(feat)
+                    valid_labels.append(class_name)
+                else:
+                    logger.warning("Feature extraction failed for an uploaded text.")
+            if feature_vectors:
+                features_np = np.array(feature_vectors).astype("float32")
+                feature_db.add_features(features_np, valid_labels)
+                feature_db.save_database()
+                logger.info("Uploaded texts processed and database updated.")
+            else:
+                logger.warning("No valid features extracted from uploaded texts.")
+        except Exception as e:
+            logger.error(f"Failed during text feature extraction and database update: {e}")
+            raise HTTPException(status_code=500, detail="Failed to process uploaded texts.")
+
+        return {
+            "message": f"Uploaded {len(saved_files)} texts to class '{class_name}' successfully."
+        }
+
     async def classify_image(self, file: UploadFile = File(...)):
         # Save the uploaded image to a temporary location
         temp_dir = "temp_uploads"
@@ -215,6 +274,21 @@ class TestTimeRouter:
 
         # Clean up temporary files
         shutil.rmtree(temp_dir)
+
+        return {"prediction": prediction}
+
+    async def classify_text(self, text: str = Form(...)):
+        try:
+            feature_vector = feature_extractor(text)
+            if feature_vector.size == 0:
+                logger.error("Feature extraction returned empty vector for text.")
+                raise HTTPException(status_code=500, detail="Failed to extract features from the text.")
+            feature_np = feature_vector.reshape(1, -1).astype("float32")
+            prediction = classifier.predict(feature_np, Settings.K_NEIGHBORS)
+            logger.info(f"Text classified as: {prediction}")
+        except Exception as e:
+            logger.error(f"Failed during text classification: {e}")
+            raise HTTPException(status_code=500, detail="Failed to classify the text.")
 
         return {"prediction": prediction}
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -12,4 +12,5 @@ class Settings:
     )
     LOGGING_LEVEL: ClassVar[str] = os.getenv("LOGGING_LEVEL", "INFO")
     FEATURE_MODEL: ClassVar[str] = os.getenv("FEATURE_MODEL", "ResNetExtractor")
+    DATA_LOADER: ClassVar[str] = os.getenv("DATA_LOADER", "DataLoader")
     K_NEIGHBORS: ClassVar[int] = int(os.getenv("K_NEIGHBORS", 5))

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,10 @@
+from .base_loader import BaseDataLoader
+from .data_loader import ImageDataLoader, DataLoader
+from .text_loader import TextDataLoader
+
+__all__ = [
+    "BaseDataLoader",
+    "ImageDataLoader",
+    "DataLoader",
+    "TextDataLoader",
+]

--- a/src/data/base_loader.py
+++ b/src/data/base_loader.py
@@ -1,0 +1,25 @@
+from abc import ABC, abstractmethod
+from typing import List, Tuple, Any
+import os
+from src.utils.logger import logger
+
+
+class BaseDataLoader(ABC):
+    """Abstract base class for loading data for the classifier."""
+
+    def __init__(self, data_path: str):
+        self.data_path = data_path
+        if not os.path.isdir(self.data_path):
+            logger.error(f"{self.data_path} is not a directory.")
+            raise NotADirectoryError(f"{self.data_path} is not a directory.")
+        os.makedirs(self.data_path, exist_ok=True)
+        self.classes = self._get_classes()
+        logger.info(f"Loaded classes: {self.classes}")
+
+    @abstractmethod
+    def _get_classes(self) -> List[str]:
+        """Return the list of available classes."""
+
+    @abstractmethod
+    def load_data(self) -> Tuple[List[Any], List[str]]:
+        """Load data and labels from disk."""

--- a/src/data/data_loader.py
+++ b/src/data/data_loader.py
@@ -2,18 +2,15 @@ import os
 from typing import List, Tuple
 from src.utils.helpers import is_image_file
 from src.utils.logger import logger
+from .base_loader import BaseDataLoader
 
 
-class DataLoader:
+class ImageDataLoader(BaseDataLoader):
+    """Load images organized in class subdirectories."""
+
     def __init__(self, data_path: str):
-        self.data_path = data_path
-        if not os.path.isdir(self.data_path):
-            logger.error(f"{self.data_path} is not a directory.")
-            raise NotADirectoryError(f"{self.data_path} is not a directory.")
-        logger.info(f"Data path: {self.data_path}")
-        os.makedirs(self.data_path, exist_ok=True)
-        self.classes = self._get_classes()
-        logger.info(f"Loaded classes: {self.classes}")
+        logger.info(f"Data path: {data_path}")
+        super().__init__(data_path)
 
     def _get_classes(self) -> List[str]:
         classes = [
@@ -42,3 +39,7 @@ class DataLoader:
                     logger.debug(f"Non-image file skipped: {file}")
         logger.info(f"Loaded {len(image_paths)} images from {self.data_path}.")
         return image_paths, labels
+
+
+# Backwards compatibility
+DataLoader = ImageDataLoader

--- a/src/data/text_loader.py
+++ b/src/data/text_loader.py
@@ -1,0 +1,37 @@
+import os
+from typing import List, Tuple
+from src.utils.logger import logger
+from .base_loader import BaseDataLoader
+
+
+class TextDataLoader(BaseDataLoader):
+    """Load text documents organized in class subdirectories."""
+
+    def __init__(self, data_path: str):
+        super().__init__(data_path)
+
+    def _get_classes(self) -> List[str]:
+        classes = [d for d in os.listdir(self.data_path) if os.path.isdir(os.path.join(self.data_path, d))]
+        if not classes:
+            logger.warning(f"No class directories found in {self.data_path}.")
+        return classes
+
+    def load_data(self) -> Tuple[List[str], List[str]]:
+        texts = []
+        labels = []
+        for label in self.classes:
+            class_dir = os.path.join(self.data_path, label)
+            if not os.path.isdir(class_dir):
+                logger.warning(f"{class_dir} is not a directory. Skipping.")
+                continue
+            for file in os.listdir(class_dir):
+                file_path = os.path.join(class_dir, file)
+                if os.path.isfile(file_path):
+                    try:
+                        with open(file_path, "r", encoding="utf-8") as f:
+                            texts.append(f.read())
+                        labels.append(label)
+                    except Exception as e:
+                        logger.error(f"Error reading {file_path}: {e}")
+        logger.info(f"Loaded {len(texts)} text documents from {self.data_path}.")
+        return texts, labels

--- a/src/features/__init__.py
+++ b/src/features/__init__.py
@@ -1,1 +1,3 @@
 from .resnet_extractor import ResNetExtractor
+from .densenet_extractor import ResNetExtractor as DenseNetExtractor
+from .text_extractor import TextFeatureExtractor

--- a/src/features/text_extractor.py
+++ b/src/features/text_extractor.py
@@ -1,0 +1,38 @@
+from typing import Union, List
+import numpy as np
+from sentence_transformers import SentenceTransformer
+from .feature_extractor import FeatureExtractor
+from src.utils.logger import logger
+
+
+class TextFeatureExtractor(FeatureExtractor):
+    """Feature extractor using pretrained sentence transformers."""
+
+    def __init__(self, model_name: str = "all-MiniLM-L6-v2", device: Union[str, None] = None):
+        self.model_name = model_name
+        super().__init__(device)
+        self.model.eval()
+
+    def _load_model(self):
+        try:
+            model = SentenceTransformer(self.model_name, device=str(self.device))
+            feature_dim = model.get_sentence_embedding_dimension()
+            logger.info(f"Loaded sentence transformer {self.model_name}")
+            return model, feature_dim
+        except Exception as e:
+            logger.error(f"Failed to load sentence transformer model {self.model_name}: {e}")
+            raise
+
+    def _extract(self, text: Union[str, List[str], None]) -> np.ndarray:
+        if text is None:
+            logger.error("Received None text for feature extraction.")
+            return np.array([])
+        try:
+            if isinstance(text, list):
+                embeddings = self.model.encode(text)
+            else:
+                embeddings = self.model.encode([text])
+            return np.array(embeddings).flatten()
+        except Exception as e:
+            logger.error(f"Error encoding text: {e}")
+            return np.array([])

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@ import argparse
 import numpy as np
 
 from src.config.settings import Settings
-from src.data.data_loader import DataLoader
+from src.data import DataLoader
 from src.features.feature_extractor import FeatureExtractor
 from src.database.feature_database import FeatureDatabase
 from src.search.similarity_search import SimilaritySearch


### PR DESCRIPTION
## Summary
- add frontend support for uploading text files and classifying text
- extend App with new tabs for text features
- introduce BaseDataLoader and update data loaders
- update documentation for text API and UI

## Testing
- `pytest -q`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684cf307683c8332bf6ae2ec10cec9c7